### PR TITLE
[libdvd*] add dvdcss, dvdread, dvdnav

### DIFF
--- a/ports/libdvdcss/0001-fix-uwp.diff
+++ b/ports/libdvdcss/0001-fix-uwp.diff
@@ -1,0 +1,530 @@
+commit 2c72a50fb032d1bbdf487b92d9e3e8ea13e82f9b
+Author: Capric <capric8416@gmail.com>
+Date:   Thu Aug 29 11:37:36 2024 +0800
+
+    [feature] add uwp support
+
+diff --git a/msvc/uwpapi.cpp b/msvc/uwpapi.cpp
+new file mode 100644
+index 0000000..0a32e72
+--- /dev/null
++++ b/msvc/uwpapi.cpp
+@@ -0,0 +1,111 @@
++
++#include <windows.h>
++#include <string>
++#include <locale>
++#include <map>
++
++using namespace Platform;
++using namespace Windows::ApplicationModel;
++using namespace Windows::System::UserProfile;
++using namespace Windows::Storage;
++using namespace Windows::Storage::Streams;
++using namespace Windows::Security::Cryptography;
++using namespace Windows::Security::Cryptography::Certificates;
++using namespace Windows::Foundation;
++
++std::wstring Utf8ToWide(const std::string &text)
++{
++  if (text.empty())
++    return L"";
++
++  int bufSize = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text.c_str(), -1, NULL, 0);
++  if (bufSize == 0)
++    return L"";
++  wchar_t *converted = new wchar_t[bufSize];
++  if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text.c_str(), -1, converted, bufSize) != bufSize)
++  {
++    delete[] converted;
++    return L"";
++  }
++
++  std::wstring Wret(converted);
++  delete[] converted;
++  return Wret;
++}
++
++std::string WideToUtf8(const std::wstring &text)
++{
++  if (text.empty())
++    return "";
++
++  int bufSize = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, text.c_str(), -1, NULL, 0, NULL, NULL);
++  if (bufSize == 0)
++    return "";
++  char * converted = new char[bufSize];
++  if (WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, text.c_str(), -1, converted, bufSize, NULL, NULL) != bufSize)
++  {
++    delete[] converted;
++    return "";
++  }
++
++  std::string ret(converted);
++  delete[] converted;
++
++  return ret;
++}
++
++extern "C" {
++    
++size_t uwp_Utf8ToW(const char* src, wchar_t* buffer, int maxlen)
++{
++  std::wstring converted = Utf8ToWide(std::string(src));
++  int len = min(converted.length(), maxlen - 1);
++  wcsncpy(buffer, converted.c_str(), len);
++  buffer[len] = '\0';
++
++  return len;
++}
++
++size_t uwp_cachepath(char *buffer, size_t cch)
++{
++  try
++  {
++    Platform::String^ path = Windows::Storage::ApplicationData::Current->LocalFolder->Path;
++    path = Platform::String::Concat(path, "\\dvdcss");
++
++    std::string utf8path = WideToUtf8(std::wstring(path->Data()));
++
++    strncpy(buffer, utf8path.c_str(), min(cch, path->Length()));
++    return min(cch, path->Length());
++  }
++  catch (Platform::Exception^)
++  {
++    return 0;
++  }
++}
++
++char* uwp_getenv(const char* n)
++{
++  static std::map<std::string, std::string> sEnvironment;
++
++  if (n == nullptr)
++    return nullptr;
++
++  std::string name(n);
++
++  // check key
++  if (!name.empty())
++  {
++    uint32_t valLen = GetEnvironmentVariableA(name.c_str(), nullptr, 0);
++    if (!valLen)
++      return nullptr;
++
++    std::string value(valLen, 0);
++    GetEnvironmentVariableA(name.c_str(), const_cast<char*>(value.c_str()), valLen);
++
++    sEnvironment[name] = value;
++    return const_cast<char*>(sEnvironment[name].c_str());
++  }
++  return nullptr;
++}
++}
+diff --git a/src/device.c b/src/device.c
+index 34b610b..b4eb138 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -93,6 +93,12 @@ static int win2k_seek  ( dvdcss_t, int );
+ static int win2k_read  ( dvdcss_t, void *, int );
+ static int win2k_readv ( dvdcss_t, const struct iovec *, int );
+ 
++#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
++extern char* uwp_getenv(const char* n);
++size_t uwp_cachepath(char *buffer, size_t cch);
++#define getenv uwp_getenv
++#endif
++
+ #elif defined( __OS2__ )
+ static int os2_open ( dvdcss_t, const char * );
+ #endif
+@@ -474,6 +480,64 @@ static int libc_open ( dvdcss_t dvdcss, const char *psz_device )
+ }
+ 
+ #if defined( _WIN32 )
++#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
++HANDLE WINAPI CreateFileW(LPCWSTR lpFileName,
++  DWORD dwDesiredAccess,
++  DWORD dwShareMode,
++  LPSECURITY_ATTRIBUTES lpSecurityAttributes,
++  DWORD dwCreationDisposition,
++  DWORD dwFlagsAndAttributes,
++  HANDLE hTemplateFile)
++{
++  CREATEFILE2_EXTENDED_PARAMETERS createExParams;
++  createExParams.dwSize = sizeof(CREATEFILE2_EXTENDED_PARAMETERS);
++  createExParams.dwFileAttributes = dwFlagsAndAttributes & 0xFFFF;
++  createExParams.dwFileFlags = dwFlagsAndAttributes & 0xFFF00000;
++  createExParams.dwSecurityQosFlags = dwFlagsAndAttributes & 0x000F00000;
++  createExParams.lpSecurityAttributes = lpSecurityAttributes;
++  createExParams.hTemplateFile = hTemplateFile;
++  return CreateFile2(lpFileName, dwDesiredAccess, dwShareMode, dwCreationDisposition, &createExParams);
++}
++extern size_t uwp_Utf8ToW(const char* src, wchar_t* buffer, int maxlen);
++
++static int win2k_open(dvdcss_t dvdcss, const char *psz_device)
++{
++  char psz_dvd[7] = "\\\\.\\\0:";
++  psz_dvd[4] = psz_device[0];
++  wchar_t pathW[7];
++  uwp_Utf8ToW(psz_dvd, pathW, 8);
++
++  /* To work around an M$ bug in IOCTL_DVD_READ_STRUCTURE, we need read
++  * _and_ write access to the device (so we can make SCSI Pass Through
++  * Requests). Unfortunately this is only allowed if you have
++  * administrator privileges so we allow for a fallback method with
++  * only read access to the device (in this case ioctl_ReadCopyright()
++  * won't send back the right result).
++  * (See Microsoft Q241374: Read and Write Access Required for SCSI
++  * Pass Through Requests) */
++  dvdcss->i_fd = (int)
++    CreateFileW(pathW, GENERIC_READ | GENERIC_WRITE,
++      FILE_SHARE_READ | FILE_SHARE_WRITE,
++      NULL, OPEN_EXISTING,
++      FILE_FLAG_RANDOM_ACCESS, NULL);
++
++  if ((HANDLE)dvdcss->i_fd == INVALID_HANDLE_VALUE)
++    dvdcss->i_fd = (int)
++    CreateFileW(pathW, GENERIC_READ, FILE_SHARE_READ,
++      NULL, OPEN_EXISTING,
++      FILE_FLAG_RANDOM_ACCESS, NULL);
++
++  if ((HANDLE)dvdcss->i_fd == INVALID_HANDLE_VALUE)
++  {
++    print_error(dvdcss, "failed to open device %s", psz_device);
++    return -1;
++  }
++
++  dvdcss->i_pos = 0;
++
++  return 0;
++}
++#else
+ static int win2k_open ( dvdcss_t dvdcss, const char *psz_device )
+ {
+     char psz_dvd[7] = "\\\\.\\\0:";
+@@ -509,6 +573,7 @@ static int win2k_open ( dvdcss_t dvdcss, const char *psz_device )
+ 
+     return 0;
+ }
++#endif
+ #endif /* defined( _WIN32 ) */
+ 
+ #ifdef __OS2__
+diff --git a/src/ioctl.c b/src/ioctl.c
+index 07bcb0d..b0775de 100644
+--- a/src/ioctl.c
++++ b/src/ioctl.c
+@@ -111,7 +111,7 @@ static void OS2InitSDC( struct OS2_ExecSCSICmd *, int );
+  *****************************************************************************/
+ int ioctl_ReadCopyright( int i_fd, int i_layer, int *pi_copyright )
+ {
+-    int i_ret;
++    int i_ret = 0;
+ 
+ #if defined( HAVE_LINUX_DVD_STRUCT )
+     dvd_struct dvd = { 0 };
+@@ -169,6 +169,7 @@ int ioctl_ReadCopyright( int i_fd, int i_layer, int *pi_copyright )
+     *pi_copyright = dvdbs.copyrightProtectionSystemType;
+ 
+ #elif defined( _WIN32 )
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     DWORD tmp;
+     SCSI_PASS_THROUGH_DIRECT sptd = { 0 };
+     uint8_t p_buffer[8];
+@@ -195,7 +196,7 @@ int ioctl_ReadCopyright( int i_fd, int i_layer, int *pi_copyright )
+     {
+         *pi_copyright = p_buffer[ 4 ];
+     }
+-
++#endif
+ #elif defined( __QNXNTO__ )
+ 
+     INIT_CPT( GPCMD_READ_DVD_STRUCTURE, 8 );
+@@ -231,7 +232,7 @@ int ioctl_ReadCopyright( int i_fd, int i_layer, int *pi_copyright )
+  *****************************************************************************/
+ int ioctl_ReadDiscKey( int i_fd, const int *pi_agid, uint8_t *p_key )
+ {
+-    int i_ret;
++    int i_ret = 0;
+ 
+ #if defined( HAVE_LINUX_DVD_STRUCT )
+     dvd_struct dvd = { 0 };
+@@ -305,6 +306,7 @@ int ioctl_ReadDiscKey( int i_fd, const int *pi_agid, uint8_t *p_key )
+     memcpy( p_key, dvdbs.discKeyStructures, DVD_DISCKEY_SIZE );
+ 
+ #elif defined( _WIN32 )
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     DWORD tmp;
+     uint8_t buffer[DVD_DISK_KEY_LENGTH] = { 0 };
+     PDVD_COPY_PROTECT_KEY key = (PDVD_COPY_PROTECT_KEY) &buffer;
+@@ -323,7 +325,7 @@ int ioctl_ReadDiscKey( int i_fd, const int *pi_agid, uint8_t *p_key )
+     }
+ 
+     memcpy( p_key, key->KeyData, DVD_DISCKEY_SIZE );
+-
++#endif
+ #elif defined( __QNXNTO__ )
+ 
+     INIT_CPT( GPCMD_READ_DVD_STRUCTURE, DVD_DISCKEY_SIZE + 4 );
+@@ -364,7 +366,7 @@ int ioctl_ReadDiscKey( int i_fd, const int *pi_agid, uint8_t *p_key )
+  *****************************************************************************/
+ int ioctl_ReadTitleKey( int i_fd, const int *pi_agid, int i_pos, uint8_t *p_key )
+ {
+-    int i_ret;
++    int i_ret = 0;
+ 
+ #if defined( HAVE_LINUX_DVD_STRUCT )
+     dvd_authinfo auth_info = { 0 };
+@@ -437,6 +439,7 @@ int ioctl_ReadTitleKey( int i_fd, const int *pi_agid, int i_pos, uint8_t *p_key
+     memcpy( p_key, dvdbs.titleKeyValue, DVD_KEY_SIZE );
+ 
+ #elif defined( _WIN32 )
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     DWORD tmp;
+     uint8_t buffer[DVD_TITLE_KEY_LENGTH] = { 0 };
+     PDVD_COPY_PROTECT_KEY key = (PDVD_COPY_PROTECT_KEY) &buffer;
+@@ -452,7 +455,7 @@ int ioctl_ReadTitleKey( int i_fd, const int *pi_agid, int i_pos, uint8_t *p_key
+             key->KeyLength, key, key->KeyLength, &tmp, NULL ) ? 0 : -1;
+ 
+     memcpy( p_key, key->KeyData, DVD_KEY_SIZE );
+-
++#endif
+ #elif defined( __QNXNTO__ )
+ 
+     INIT_CPT( GPCMD_REPORT_KEY, 12 );
+@@ -496,7 +499,7 @@ int ioctl_ReadTitleKey( int i_fd, const int *pi_agid, int i_pos, uint8_t *p_key
+  *****************************************************************************/
+ int ioctl_ReportAgid( int i_fd, int *pi_agid )
+ {
+-    int i_ret;
++    int i_ret = 0;
+ 
+ #if defined( HAVE_LINUX_DVD_STRUCT )
+     dvd_authinfo auth_info = { 0 };
+@@ -553,11 +556,12 @@ int ioctl_ReportAgid( int i_fd, int *pi_agid )
+     *pi_agid = dvdbs.grantID;
+ 
+ #elif defined( _WIN32 )
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     DWORD tmp = 0;
+ 
+     i_ret = DeviceIoControl( (HANDLE) i_fd, IOCTL_DVD_START_SESSION, &tmp, 4,
+                              pi_agid, sizeof( *pi_agid ), &tmp, NULL ) ? 0 : -1;
+-
++#endif
+ #elif defined( __QNXNTO__ )
+ 
+     INIT_CPT( GPCMD_REPORT_KEY, 8 );
+@@ -591,7 +595,7 @@ int ioctl_ReportAgid( int i_fd, int *pi_agid )
+  *****************************************************************************/
+ int ioctl_ReportChallenge( int i_fd, const int *pi_agid, uint8_t *p_challenge )
+ {
+-    int i_ret;
++    int i_ret = 0;
+ 
+ #if defined( HAVE_LINUX_DVD_STRUCT )
+     dvd_authinfo auth_info = { 0 };
+@@ -647,6 +651,7 @@ int ioctl_ReportChallenge( int i_fd, const int *pi_agid, uint8_t *p_challenge )
+     memcpy( p_challenge, dvdbs.challengeKeyValue, DVD_CHALLENGE_SIZE );
+ 
+ #elif defined( _WIN32 )
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     DWORD tmp;
+     uint8_t buffer[DVD_CHALLENGE_KEY_LENGTH] = { 0 };
+     PDVD_COPY_PROTECT_KEY key = (PDVD_COPY_PROTECT_KEY) &buffer;
+@@ -665,7 +670,7 @@ int ioctl_ReportChallenge( int i_fd, const int *pi_agid, uint8_t *p_challenge )
+     }
+ 
+     memcpy( p_challenge, key->KeyData, DVD_CHALLENGE_SIZE );
+-
++#endif
+ #elif defined( __QNXNTO__ )
+ 
+     INIT_CPT( GPCMD_REPORT_KEY, 16 );
+@@ -699,7 +704,7 @@ int ioctl_ReportChallenge( int i_fd, const int *pi_agid, uint8_t *p_challenge )
+  *****************************************************************************/
+ int ioctl_ReportASF( int i_fd, int *pi_asf )
+ {
+-    int i_ret;
++    int i_ret = 0;
+ 
+ #if defined( HAVE_LINUX_DVD_STRUCT )
+     dvd_authinfo auth_info = { 0 };
+@@ -753,6 +758,7 @@ int ioctl_ReportASF( int i_fd, int *pi_asf )
+     *pi_asf = dvdbs.successFlag;
+ 
+ #elif defined( _WIN32 )
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     DWORD tmp;
+     uint8_t buffer[DVD_ASF_LENGTH] = { 0 };
+     PDVD_COPY_PROTECT_KEY key = (PDVD_COPY_PROTECT_KEY) &buffer;
+@@ -775,7 +781,7 @@ int ioctl_ReportASF( int i_fd, int *pi_asf )
+ 
+     keyData = (PDVD_ASF)key->KeyData;
+     *pi_asf = keyData->SuccessFlag;
+-
++#endif
+ #elif defined( __QNXNTO__ )
+ 
+     INIT_CPT( GPCMD_REPORT_KEY, 8 );
+@@ -809,7 +815,7 @@ int ioctl_ReportASF( int i_fd, int *pi_asf )
+  *****************************************************************************/
+ int ioctl_ReportKey1( int i_fd, const int *pi_agid, uint8_t *p_key )
+ {
+-    int i_ret;
++    int i_ret = 0;
+ 
+ #if defined( HAVE_LINUX_DVD_STRUCT )
+     dvd_authinfo auth_info = { 0 };
+@@ -865,6 +871,7 @@ int ioctl_ReportKey1( int i_fd, const int *pi_agid, uint8_t *p_key )
+     memcpy( p_key, dvdbs.key1Value, DVD_KEY_SIZE );
+ 
+ #elif defined( _WIN32 )
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     DWORD tmp;
+     uint8_t buffer[DVD_BUS_KEY_LENGTH] = { 0 };
+     PDVD_COPY_PROTECT_KEY key = (PDVD_COPY_PROTECT_KEY) &buffer;
+@@ -878,7 +885,7 @@ int ioctl_ReportKey1( int i_fd, const int *pi_agid, uint8_t *p_key )
+             key->KeyLength, key, key->KeyLength, &tmp, NULL ) ? 0 : -1;
+ 
+     memcpy( p_key, key->KeyData, DVD_KEY_SIZE );
+-
++#endif
+ #elif defined( __QNXNTO__ )
+ 
+     INIT_CPT( GPCMD_REPORT_KEY, 12 );
+@@ -912,7 +919,7 @@ int ioctl_ReportKey1( int i_fd, const int *pi_agid, uint8_t *p_key )
+  *****************************************************************************/
+ int ioctl_InvalidateAgid( int i_fd, int *pi_agid )
+ {
+-    int i_ret;
++    int i_ret = 0;
+ 
+ #if defined( HAVE_LINUX_DVD_STRUCT )
+     dvd_authinfo auth_info = { 0 };
+@@ -958,11 +965,12 @@ int ioctl_InvalidateAgid( int i_fd, int *pi_agid )
+     i_ret = ioctl( i_fd, DKIOCDVDSENDKEY, &dvd );
+ 
+ #elif defined( _WIN32 )
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     DWORD tmp;
+ 
+     i_ret = DeviceIoControl( (HANDLE) i_fd, IOCTL_DVD_END_SESSION,
+                 pi_agid, sizeof( *pi_agid ), NULL, 0, &tmp, NULL ) ? 0 : -1;
+-
++#endif
+ #elif defined( __QNXNTO__ )
+ 
+     INIT_CPT( GPCMD_REPORT_KEY, 0 );
+@@ -995,7 +1003,7 @@ int ioctl_InvalidateAgid( int i_fd, int *pi_agid )
+  *****************************************************************************/
+ int ioctl_SendChallenge( int i_fd, const int *pi_agid, const uint8_t *p_challenge )
+ {
+-    int i_ret;
++    int i_ret = 0;
+ 
+ #if defined( HAVE_LINUX_DVD_STRUCT )
+     dvd_authinfo auth_info = { 0 };
+@@ -1055,6 +1063,7 @@ int ioctl_SendChallenge( int i_fd, const int *pi_agid, const uint8_t *p_challeng
+     i_ret = ioctl( i_fd, DKIOCDVDSENDKEY, &dvd );
+ 
+ #elif defined( _WIN32 )
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     DWORD tmp;
+     uint8_t buffer[DVD_CHALLENGE_KEY_LENGTH] = { 0 };
+     PDVD_COPY_PROTECT_KEY key = (PDVD_COPY_PROTECT_KEY) &buffer;
+@@ -1068,7 +1077,7 @@ int ioctl_SendChallenge( int i_fd, const int *pi_agid, const uint8_t *p_challeng
+ 
+     i_ret = DeviceIoControl( (HANDLE) i_fd, IOCTL_DVD_SEND_KEY, key,
+              key->KeyLength, key, key->KeyLength, &tmp, NULL ) ? 0 : -1;
+-
++#endif
+ #elif defined( __QNXNTO__ )
+ 
+     INIT_CPT( GPCMD_SEND_KEY, 16 );
+@@ -1104,7 +1113,7 @@ int ioctl_SendChallenge( int i_fd, const int *pi_agid, const uint8_t *p_challeng
+  *****************************************************************************/
+ int ioctl_SendKey2( int i_fd, const int *pi_agid, const uint8_t *p_key )
+ {
+-    int i_ret;
++    int i_ret = 0;
+ 
+ #if defined( HAVE_LINUX_DVD_STRUCT )
+     dvd_authinfo auth_info = { 0 };
+@@ -1164,6 +1173,7 @@ int ioctl_SendKey2( int i_fd, const int *pi_agid, const uint8_t *p_key )
+     i_ret = ioctl( i_fd, DKIOCDVDSENDKEY, &dvd );
+ 
+ #elif defined( _WIN32 )
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     DWORD tmp;
+     uint8_t buffer[DVD_BUS_KEY_LENGTH] = { 0 };
+     PDVD_COPY_PROTECT_KEY key = (PDVD_COPY_PROTECT_KEY) &buffer;
+@@ -1177,7 +1187,7 @@ int ioctl_SendKey2( int i_fd, const int *pi_agid, const uint8_t *p_key )
+ 
+     i_ret = DeviceIoControl( (HANDLE) i_fd, IOCTL_DVD_SEND_KEY, key,
+              key->KeyLength, key, key->KeyLength, &tmp, NULL ) ? 0 : -1;
+-
++#endif
+ #elif defined( __QNXNTO__ )
+ 
+     INIT_CPT( GPCMD_SEND_KEY, 12 );
+@@ -1213,7 +1223,7 @@ int ioctl_SendKey2( int i_fd, const int *pi_agid, const uint8_t *p_key )
+  *****************************************************************************/
+ int ioctl_ReportRPC( int i_fd, int *p_type, int *p_mask, int *p_scheme )
+ {
+-    int i_ret;
++    int i_ret = 0;
+ 
+ #if defined( HAVE_LINUX_DVD_STRUCT ) && defined( DVD_LU_SEND_RPC_STATE )
+     dvd_authinfo auth_info = { 0 };
+@@ -1281,6 +1291,7 @@ int ioctl_ReportRPC( int i_fd, int *p_type, int *p_mask, int *p_scheme )
+     *p_scheme = dvdbs.rpcScheme;
+ 
+ #elif defined( _WIN32 )
++#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     DWORD tmp;
+     uint8_t buffer[DVD_RPC_KEY_LENGTH] = { 0 };
+     PDVD_COPY_PROTECT_KEY key = (PDVD_COPY_PROTECT_KEY) &buffer;
+@@ -1302,7 +1313,7 @@ int ioctl_ReportRPC( int i_fd, int *p_type, int *p_mask, int *p_scheme )
+     *p_type = keyData->TypeCode;
+     *p_mask = keyData->RegionMask;
+     *p_scheme = keyData->RpcScheme;
+-
++#endif
+ #elif defined( __QNXNTO__ )
+ 
+     INIT_CPT( GPCMD_REPORT_KEY, 8 );
+diff --git a/src/libdvdcss.c b/src/libdvdcss.c
+index 78067a1..46c907d 100644
+--- a/src/libdvdcss.c
++++ b/src/libdvdcss.c
+@@ -143,6 +143,12 @@
+ #define MANUFACTURING_DATE_OFFSET 813
+ #define MANUFACTURING_DATE_LENGTH  16
+ 
++#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
++extern char* uwp_getenv(const char* n);
++size_t uwp_cachepath(char *buffer, size_t cch);
++#define getenv uwp_getenv
++#endif
++
+ static int exists_or_mkdir( const char *path, int perm )
+ {
+     /* mkdir() may return an error if making the directory would fail,
+@@ -215,11 +221,14 @@ static int set_cache_directory( dvdcss_t dvdcss )
+     {
+ #ifdef _WIN32
+         char psz_home[PATH_MAX];
+-
++#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
++        if (uwp_cachepath(psz_home, PATH_MAX))
++#else
+         /* Cache our keys in
+          * C:\Documents and Settings\$USER\Application Data\dvdcss\ */
+         if (SHGetFolderPathA (NULL, CSIDL_APPDATA | CSIDL_FLAG_CREATE,
+                               NULL, SHGFP_TYPE_CURRENT, psz_home ) == S_OK)
++#endif
+         {
+             snprintf( dvdcss->psz_cachefile, PATH_MAX, "%s\\dvdcss", psz_home );
+             dvdcss->psz_cachefile[PATH_MAX - 1] = '\0';

--- a/ports/libdvdcss/0002-add-msvc-exports-def.diff
+++ b/ports/libdvdcss/0002-add-msvc-exports-def.diff
@@ -1,0 +1,25 @@
+commit dd623fcb9075d1f7c4a25b7e416bff2c5e9db73a
+Author: Capric <capric8416@gmail.com>
+Date:   Thu Aug 29 17:07:54 2024 +0800
+
+    [feature] add msvc exports def
+
+diff --git a/msvc/libdvdcss.def b/msvc/libdvdcss.def
+new file mode 100644
+index 0000000..72be4e3
+--- /dev/null
++++ b/msvc/libdvdcss.def
+@@ -0,0 +1,13 @@
++;------------------------------------------------------------
++; LIBDVDCSS DLL DEFINITIONS FILE
++
++EXPORTS
++
++dvdcss_open
++dvdcss_open_stream
++dvdcss_close
++dvdcss_seek
++dvdcss_read
++dvdcss_readv
++dvdcss_error
++dvdcss_is_scrambled

--- a/ports/libdvdcss/CMakeLists.txt
+++ b/ports/libdvdcss/CMakeLists.txt
@@ -1,0 +1,187 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(libdvdcss C)
+
+set(DVDCSS_VERSION_MAJOR 1)
+set(DVDCSS_VERSION_MINOR 4)
+set(DVDCSS_VERSION_MICRO 2)
+
+set(LIBDVDCSS_VERSION "${DVDCSS_VERSION_MAJOR}.${DVDCSS_VERSION_MINOR}.${DVDCSS_VERSION_MICRO}")
+
+include(CheckIncludeFiles)
+include(CheckSymbolExists)
+include(CheckTypeSize)
+include(CheckFunctionExists)
+include(CMakePackageConfigHelpers)
+
+check_include_files("IOKit/storage/IODVDMediaBSDClient.h" DARWIN_DVD_IOCTL)
+check_include_files("linux/cdrom.h" DVD_STRUCT_IN_LINUX_CDROM_H)
+check_include_files("linux/cdrom.h" HAVE_LINUX_CDROM_H)
+check_include_files("sys/cdio.h" DVD_STRUCT_IN_SYS_CDIO_H)
+check_include_files("sys/cdio.h" HAVE_SYS_CDIO_H)
+check_include_files("sys/dvdio.h" DVD_STRUCT_IN_SYS_DVDIO_H)
+check_include_files("sys/dvdio.h" HAVE_SYS_DVDIO_H)
+check_include_files("dlfcn.h" HAVE_DLFCN_H)
+check_include_files("dvd.h" HAVE_DVD_H)
+check_include_files("errno.h" HAVE_ERRNO_H)
+check_include_files("fcntl.h" HAVE_FCNTL_H)
+check_include_files("inttypes.h" HAVE_INTTYPES_H)
+check_include_files("io.h" HAVE_IO_H)
+check_include_files("memory.h" HAVE_MEMORY_H)
+check_include_files("pwd.h" HAVE_PWD_H)
+check_include_files("stdint.h" HAVE_STDINT_H)
+check_include_files("stdlib.h" HAVE_STDLIB_H)
+check_include_files("strings.h" HAVE_STRINGS_H)
+check_include_files("string.h" HAVE_STRING_H)
+check_include_files("sys/ioctl.h" HAVE_SYS_IOCTL_H)
+check_include_files("sys/param.h" HAVE_SYS_PARAM_H)
+check_include_files("sys/scsi/impl/uscsi.h" HAVE_SYS_SCSI_IMPL_USCSI_H)
+check_include_files("sys/scsi/scsi_types.h" HAVE_SYS_SCSI_SCSI_TYPES_H)
+check_include_files("sys/stat.h" HAVE_SYS_STAT_H)
+check_include_files("sys/types.h" HAVE_SYS_TYPES_H)
+check_include_files("sys/uio.h" HAVE_SYS_UIO_H)
+check_include_files("unistd.h" HAVE_UNISTD_H)
+check_include_files("windows.h" HAVE_WINDOWS_H)
+check_include_files("winioctl.h" HAVE_WINIOCTL_H)
+
+check_function_exists("mkdir" HAVE_MKDIR_F)
+if(NOT HAVE_MKDIR_F OR MSVC)
+  set(HAVE_BROKEN_MKDIR 1)
+endif()
+
+if(HAVE_SYS_CDIO_H)
+  set(BSD_DVD_STRUCT 1)
+  set(LINUX_DVD_STRUCT 1)
+  set(OPENBSD_DVD_STRUCT 1)
+endif()
+
+if(HAVE_SYS_DVDIO_H)
+  set(BSD_DVD_STRUCT 1)
+  set(LINUX_DVD_STRUCT 1)
+endif()
+
+if(HAVE_LINUX_CDROM_H)
+  set(LINUX_DVD_STRUCT 1)
+endif()
+
+check_type_size(size_t SIZE_T)
+if(NOT HAVE_SIZE_T)
+  if("${CMAKE_SIZEOF_VOID_P}" EQUAL 8)
+    set(size_t "uint64_t")
+  else("${CMAKE_SIZEOF_VOID_P}" EQUAL 8)
+    set(size_t   "uint32_t")
+  endif("${CMAKE_SIZEOF_VOID_P}" EQUAL 8)
+endif(NOT HAVE_SIZE_T)
+
+if(LINUX_DVD_STRUCT)
+  set(HAVE_LINUX_DVD_STRUCT 1)
+  if(OPENBSD_DVD_STRUCT)
+    set(HAVE_OPENBSD_DVD_STRUCT 1)
+  endif()
+elseif(BSD_DVD_STRUCT)
+  set(HAVE_BSD_DVD_STRUCT 1)
+endif()
+
+set(PACKAGE ${PROJECT_NAME})
+set(PACKAGE_NAME ${PROJECT_NAME})
+set(PACKAGE_STRING "${PROJECT_NAME} ${LIBDVDCSS_VERSION}")
+set(PACKAGE_TARNAME ${PROJECT_NAME})
+set(PACKAGE_URL "https://www.videolan.org/developers/libdvdcss.html")
+set(PACKAGE_VERSION ${LIBDVDCSS_VERSION})
+set(STDC_HEADERS 1)
+set(SUPPORT_ATTRIBUTE_VISIBILITY_DEFAULT 1)
+set(SUPPORT_FLAG_VISIBILITY 1)
+set(VERSION ${LIBDVDCSS_VERSION})
+set(_WIN32_IE "0x0600")
+
+check_symbol_exists(O_BINARY "fcntl.h" HAVE_O_BINARY)
+if(NOT HAVE_O_BINARY)
+  set(O_BINARY 1)
+endif()
+
+configure_file(${CMAKE_SOURCE_DIR}/config.h.cm ${CMAKE_BINARY_DIR}/config.h)
+configure_file(${CMAKE_SOURCE_DIR}/src/dvdcss/version.h.in ${CMAKE_BINARY_DIR}/version.h @ONLY)
+
+add_library(${PROJECT_NAME} 
+    src/common.h
+    src/css.c
+    src/css.h
+    src/csstables.h
+    src/device.c
+    src/device.h
+    src/error.c
+    src/ioctl.c
+    src/ioctl.h
+    src/libdvdcss.c
+    src/libdvdcss.h
+    src/dvdcss/dvdcss.h
+)
+
+add_library(unofficial::${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+target_include_directories(${PROJECT_NAME}
+  PRIVATE
+  "."
+  "src"
+  "src/dvdcss"
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+if(MSVC)
+  target_compile_definitions(${PROJECT_NAME}
+    PRIVATE 
+      LIBDVDCSS_EXPORTS 
+      _CRT_SECURE_NO_WARNINGS
+      PATH_MAX=1024
+  )
+  set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_SOURCE_DIR}/msvc/libdvdcss.def\"")
+  if(CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+    enable_language(CXX)
+    target_sources(${PROJECT_NAME} 
+      PRIVATE
+        ${CMAKE_SOURCE_DIR}/msvc/uwpapi.cpp
+    )
+    set_source_files_properties(${CMAKE_SOURCE_DIR}/msvc/uwpapi.cpp PROPERTIES COMPILE_FLAGS "/TP /ZW")
+    set_target_properties(${PROJECT_NAME}
+        PROPERTIES
+          LINK_FLAGS_DEBUG "/defaultlib:vccorlibd.lib /defaultlib:msvcrtd.lib"
+          LINK_FLAGS_RELEASE "/defaultlib:vccorlib.lib /defaultlib:msvcrt.lib"
+          LINK_FLAGS_RELWITHDEBINFO "/defaultlib:vccorlib.lib /defaultlib:msvcrt.lib"
+    )
+  endif()
+endif()
+
+target_include_directories(${PROJECT_NAME}
+    INTERFACE
+        $<INSTALL_INTERFACE:include>
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-targets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(FILES
+  ${CMAKE_CURRENT_LIST_DIR}/src/dvdcss/dvdcss.h
+  ${CMAKE_CURRENT_BINARY_DIR}/version.h
+  DESTINATION include/dvdcss)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  INSTALL_DESTINATION "share/${PROJECT_NAME}"
+)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  DESTINATION "share/${PROJECT_NAME}"
+)
+
+install(
+    EXPORT ${PROJECT_NAME}-targets
+    DESTINATION share/${PROJECT_NAME}
+    NAMESPACE unofficial::${PROJECT_NAME}::
+)

--- a/ports/libdvdcss/config.h.cm
+++ b/ports/libdvdcss/config.h.cm
@@ -1,0 +1,169 @@
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Have IOKit DVD IOCTL headers */
+#cmakedefine DARWIN_DVD_IOCTL 1
+
+/* Define if <linux/cdrom.h> defines DVD_STRUCT. */
+#cmakedefine DVD_STRUCT_IN_LINUX_CDROM_H 1
+
+/* Define if <sys/cdio.h> defines dvd_struct. */
+#cmakedefine DVD_STRUCT_IN_SYS_CDIO_H 1
+
+/* Define if <sys/dvdio.h> defines dvd_struct. */
+#cmakedefine DVD_STRUCT_IN_SYS_DVDIO_H 1
+
+/* Define if you have a broken mkdir */
+#cmakedefine HAVE_BROKEN_MKDIR 1
+
+/* Define if FreeBSD-like dvd_struct is defined. */
+#cmakedefine HAVE_BSD_DVD_STRUCT 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#cmakedefine HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <dvd.h> header file. */
+#cmakedefine HAVE_DVD_H 1
+
+/* Define to 1 if you have the <errno.h> header file. */
+#cmakedefine HAVE_ERRNO_H 1
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#cmakedefine HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <io.h> header file. */
+#cmakedefine HAVE_IO_H 1
+
+/* Define to 1 if you have the <linux/cdrom.h> header file. */
+#cmakedefine HAVE_LINUX_CDROM_H 1
+
+/* Define if Linux-like dvd_struct is defined. */
+#cmakedefine HAVE_LINUX_DVD_STRUCT 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#cmakedefine HAVE_MEMORY_H 1
+
+/* Define if OpenBSD-like dvd_struct is defined. */
+#cmakedefine HAVE_OPENBSD_DVD_STRUCT 1
+
+/* Define to 1 if you have the <pwd.h> header file. */
+#cmakedefine HAVE_PWD_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#cmakedefine HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/cdio.h> header file. */
+#cmakedefine HAVE_SYS_CDIO_H 1
+
+/* Define to 1 if you have the <sys/dvdio.h> header file. */
+#cmakedefine HAVE_SYS_DVDIO_H 1
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#cmakedefine HAVE_SYS_IOCTL_H 1
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#cmakedefine HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/scsi/impl/uscsi.h> header file. */
+#cmakedefine HAVE_SYS_SCSI_IMPL_USCSI_H 1
+
+/* Define to 1 if you have the <sys/scsi/scsi_types.h> header file. */
+#cmakedefine HAVE_SYS_SCSI_SCSI_TYPES_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#cmakedefine HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#cmakedefine HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <sys/uio.h> header file. */
+#cmakedefine HAVE_SYS_UIO_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the <windows.h> header file. */
+#cmakedefine HAVE_WINDOWS_H 1
+
+/* Define to 1 if you have the <winioctl.h> header file. */
+#cmakedefine HAVE_WINIOCTL_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#cmakedefine LT_OBJDIR "${LT_OBJDIR}"
+
+/* Define O_BINARY if missing */
+#cmakedefine O_BINARY ${O_BINARY}
+
+/* Name of package */
+#cmakedefine PACKAGE "${PACKAGE}"
+
+/* Define to the address where bug reports for this package should be sent. */
+#cmakedefine PACKAGE_BUGREPORT "${PACKAGE_BUGREPORT}"
+
+/* Define to the full name of this package. */
+#cmakedefine PACKAGE_NAME "${PACKAGE_NAME}"
+
+/* Define to the full name and version of this package. */
+#cmakedefine PACKAGE_STRING "${PACKAGE_STRING}"
+
+/* Define to the one symbol short name of this package. */
+#cmakedefine PACKAGE_TARNAME "${PACKAGE_TARNAME}"
+
+/* Define to the home page for this package. */
+#cmakedefine PACKAGE_URL "${PACKAGE_URL}"
+
+/* Define to the version of this package. */
+#cmakedefine PACKAGE_VERSION "${PACKAGE_VERSION}"
+
+/* Have userspace SCSI headers. */
+#cmakedefine SOLARIS_USCSI 1
+
+/* Define to 1 if you have the ANSI C header files. */
+#cmakedefine STDC_HEADERS 1
+
+/* Define this if the compiler supports __attribute__((visibility("default")))
+   */
+#cmakedefine SUPPORT_ATTRIBUTE_VISIBILITY_DEFAULT 1
+
+/* Define this if the compiler supports the -fvisibility flag */
+#cmakedefine SUPPORT_FLAG_VISIBILITY 1
+
+/* Version number of package */
+#cmakedefine VERSION "${VERSION}"
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#cmakedefine _FILE_OFFSET_BITS ${_FILE_OFFSET_BITS}
+
+/* Define for large files, on AIX-style hosts. */
+#cmakedefine _LARGE_FILES 1
+
+/* Define to '0x0501' for IE 5.01 (and shell) APIs. */
+#cmakedefine _WIN32_IE ${_WIN32_IE}
+
+/* Define to empty if `const' does not conform to ANSI C. */
+/* #undef const */
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+#cmakedefine inline
+#endif
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+#cmakedefine size_t ${size_t}

--- a/ports/libdvdcss/libdvdcss-config.cmake.in
+++ b/ports/libdvdcss/libdvdcss-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libdvdcss-targets.cmake")
+
+check_required_components(libdvdcss)

--- a/ports/libdvdcss/portfile.cmake
+++ b/ports/libdvdcss/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL "https://code.videolan.org/videolan/libdvdcss.git"
+    REF d0b6a291c24eda3727ad5c7a14956fc1fc82446d # 1.4.2
+    HEAD_REF master
+    PATCHES
+        0001-fix-uwp.diff
+        0002-add-msvc-exports-def.diff
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/config.h.cm" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/libdvdcss-config.cmake.in" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libdvdcss/vcpkg.json
+++ b/ports/libdvdcss/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libdvdcss",
+  "version-semver": "1.4.2",
+  "description": "Accessing DVDs like a block device library",
+  "homepage": "https://www.videolan.org/developers/libdvdcss.html",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/libdvdnav/0001-fix-include-missing-on-windows.diff
+++ b/ports/libdvdnav/0001-fix-include-missing-on-windows.diff
@@ -1,0 +1,179 @@
+commit cc4731c2ec19af1d790ed96b66c623d0d633b646
+Author: Capric <capric8416@gmail.com>
+Date:   Thu Aug 29 21:45:02 2024 +0800
+
+    [hotfix] fix include missing on windows
+
+diff --git a/msvc/contrib/timer/timer.h b/msvc/contrib/timer/timer.h
+index efab6f4..77b1b66 100644
+--- a/msvc/contrib/timer/timer.h
++++ b/msvc/contrib/timer/timer.h
+@@ -1,5 +1,5 @@
+ #include <time.h>
+-#include <winsock.h>
++#include <winsock2.h>
+ #include "pthread.h"
+ 
+ #ifndef _ITIMER_
+diff --git a/msvc/include/dvdnav_internal.h b/msvc/include/dvdnav_internal.h
+index a5e7eb4..fc8af27 100644
+--- a/msvc/include/dvdnav_internal.h
++++ b/msvc/include/dvdnav_internal.h
+@@ -32,6 +32,7 @@
+ #include <limits.h>
+ #include <string.h>
+ #include <pthread.h>
++#include <stdint.h>
+ 
+ #undef WORDS_BIGENDIAN
+ 
+diff --git a/msvc/include/sys/time.h b/msvc/include/sys/time.h
+index fe7fd84..e0767a7 100644
+--- a/msvc/include/sys/time.h
++++ b/msvc/include/sys/time.h
+@@ -25,4 +25,10 @@
+  *				timer functions.
+  */
+ 
++#pragma once
++
+ #include <time.h>
++
++#ifdef _MSC_VER
++#include <WinSock2.h>
++#endif
+diff --git a/msvc/include/timer.h b/msvc/include/timer.h
+index efab6f4..77b1b66 100644
+--- a/msvc/include/timer.h
++++ b/msvc/include/timer.h
+@@ -1,5 +1,5 @@
+ #include <time.h>
+-#include <winsock.h>
++#include <winsock2.h>
+ #include "pthread.h"
+ 
+ #ifndef _ITIMER_
+diff --git a/src/dvdnav.c b/src/dvdnav.c
+index 4ef7d1a..2cd9b7a 100644
+--- a/src/dvdnav.c
++++ b/src/dvdnav.c
+@@ -34,6 +34,7 @@
+ #include <unistd.h>
+ #include <limits.h>
+ #include <string.h>
++#include <stdint.h>
+ #include <sys/time.h>
+ #include "dvdnav/dvdnav.h"
+ #include <dvdread/dvd_reader.h>
+diff --git a/src/dvdnav/dvdnav.h b/src/dvdnav/dvdnav.h
+index 85136a4..bb82549 100644
+--- a/src/dvdnav/dvdnav.h
++++ b/src/dvdnav/dvdnav.h
+@@ -31,6 +31,7 @@ extern "C" {
+ #endif
+ 
+ #include "version.h"
++#include <stdint.h>
+ #include <dvdnav/dvd_types.h>
+ #include <dvdread/dvd_reader.h>
+ #include <dvdread/nav_types.h>
+diff --git a/src/dvdnav_internal.h b/src/dvdnav_internal.h
+index 3b49aa2..04b16d7 100644
+--- a/src/dvdnav_internal.h
++++ b/src/dvdnav_internal.h
+@@ -43,7 +43,7 @@ static inline int _private_gettimeofday( struct timeval *tv, void *tz )
+ {
+   struct timeb t;
+   ftime( &t );
+-  tv->tv_sec = t.time;
++  tv->tv_sec = (long)t.time;
+   tv->tv_usec = t.millitm * 1000;
+   return 0;
+ }
+diff --git a/src/highlight.c b/src/highlight.c
+index 9954347..17e0eef 100644
+--- a/src/highlight.c
++++ b/src/highlight.c
+@@ -29,6 +29,7 @@
+ #include <limits.h>
+ #include <string.h>
+ #include <sys/time.h>
++#include <stdint.h>
+ #include <dvdread/nav_types.h>
+ #include "dvdnav/dvdnav.h"
+ #include "vm/decoder.h"
+diff --git a/src/vm/decoder.c b/src/vm/decoder.c
+index 7dd8da2..6563129 100644
+--- a/src/vm/decoder.c
++++ b/src/vm/decoder.c
+@@ -27,6 +27,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <inttypes.h>
++#include <stdint.h>
+ #include <limits.h>
+ #include <string.h>  /* For memset */
+ #include <sys/time.h>
+diff --git a/src/vm/decoder.h b/src/vm/decoder.h
+index 82cd6ed..f8bea88 100644
+--- a/src/vm/decoder.h
++++ b/src/vm/decoder.h
+@@ -24,6 +24,10 @@
+ 
+ #include <sys/time.h>
+ 
++#ifdef _WIN32
++#include <WinSock2.h>
++#endif
++
+ /* link command types */
+ typedef enum {
+   LinkNoLink  = 0,
+diff --git a/src/vm/getset.c b/src/vm/getset.c
+index 4132b1c..f3e6612 100644
+--- a/src/vm/getset.c
++++ b/src/vm/getset.c
+@@ -29,6 +29,7 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <inttypes.h>
++#include <stdint.h>
+ 
+ #include <dvdread/nav_types.h>
+ #include <dvdread/ifo_read.h>
+diff --git a/src/vm/play.c b/src/vm/play.c
+index 8830883..f9abadd 100644
+--- a/src/vm/play.c
++++ b/src/vm/play.c
+@@ -28,6 +28,7 @@
+ #include <assert.h>
+ #include <stdlib.h>
+ #include <stdio.h>
++#include <stdint.h>
+ 
+ #include <dvdread/nav_types.h>
+ #include <dvdread/ifo_read.h>
+diff --git a/src/vm/vm.c b/src/vm/vm.c
+index 9276c91..08cd61c 100644
+--- a/src/vm/vm.c
++++ b/src/vm/vm.c
+@@ -37,6 +37,7 @@
+ #include <sys/time.h>
+ #include <fcntl.h>
+ #include <ctype.h>
++#include <stdint.h>
+ 
+ #include <dvdread/nav_types.h>
+ #include <dvdread/ifo_read.h>
+diff --git a/src/vm/vmget.c b/src/vm/vmget.c
+index 5816f2c..ae14b31 100644
+--- a/src/vm/vmget.c
++++ b/src/vm/vmget.c
+@@ -30,6 +30,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <stdlib.h>
++#include <stdint.h>
+ 
+ #include <dvdread/nav_types.h>
+ #include <dvdread/ifo_read.h>

--- a/ports/libdvdnav/0002-add-msvc-exports-def.diff
+++ b/ports/libdvdnav/0002-add-msvc-exports-def.diff
@@ -1,0 +1,122 @@
+commit 7ccc8044b1c42759af1122a68ae134a99341d719
+Author: Capric <capric8416@gmail.com>
+Date:   Thu Aug 29 22:06:27 2024 +0800
+
+    [feature] update msvc exports def
+
+diff --git a/msvc/libdvdnav.def b/msvc/libdvdnav.def
+index 7f633d1..84e5420 100644
+--- a/msvc/libdvdnav.def
++++ b/msvc/libdvdnav.def
+@@ -3,29 +3,89 @@
+ 
+ EXPORTS
+ 
++
++
++; libdvdcss
++dvdcss_open
++dvdcss_open_stream
++dvdcss_close
++dvdcss_seek
++dvdcss_read
++dvdcss_readv
++dvdcss_error
++dvdcss_is_scrambled
++
++
++
++; libdvdread
++dvdread_getbits_init
++dvdread_getbits
++
+ DVDOpen
++DVDOpen2
++DVDOpenStream
++DVDOpenStream2
+ DVDClose
++DVDFileStat
+ DVDOpenFile
+ DVDCloseFile
+ DVDReadBlocks
++DVDFileSeek
++DVDReadBytes
++DVDFileSize
++DVDDiscID
++DVDUDFVolumeInfo
++DVDFileSeekForce
++DVDISOVolumeInfo
++DVDUDFCacheLevel
+ 
+-navRead_DSI
+-navRead_PCI
++UDFFindFile
++UDFGetVolumeIdentifier
++UDFGetVolumeSetIdentifier
+ 
++ifo_print
++dvdread_print_time
++
++ifoOpen
++ifoOpenVMGI
++ifoOpenVTSI
+ ifoClose
+-ifoRead_VOBU_ADMAP
+-ifoRead_VTS_ATRT
+ ifoRead_PTL_MAIT
+-ifoRead_PGCI_UT
++ifoRead_VTS_ATRT
+ ifoRead_TT_SRPT
++ifoRead_VTS_PTT_SRPT
+ ifoRead_FP_PGC
+-ifoOpenVMGI
+-ifoRead_TITLE_VOBU_ADMAP
+ ifoRead_PGCIT
+-ifoRead_VTS_PTT_SRPT
+-ifoOpenVTSI
+-ifoPrint
++ifoRead_PGCI_UT
++ifoRead_VTS_TMAPT
++ifoRead_C_ADT
++ifoRead_TITLE_C_ADT
++ifoRead_VOBU_ADMAP
++ifoRead_TITLE_VOBU_ADMAP
++ifoRead_TXTDT_MGI
++ifoFree_PTL_MAIT
++ifoFree_VTS_ATRT
++ifoFree_TT_SRPT
++ifoFree_VTS_PTT_SRPT
++ifoFree_FP_PGC
++ifoFree_PGCIT
++ifoFree_PGCI_UT
++ifoFree_VTS_TMAPT
++ifoFree_C_ADT
++ifoFree_TITLE_C_ADT
++ifoFree_VOBU_ADMAP
++ifoFree_TITLE_VOBU_ADMAP
++ifoFree_TXTDT_MGI
++
++navPrint_PCI
++navPrint_DSI
+ 
++navRead_DSI
++navRead_PCI
++
++
++
++; libdvdnav
+ dvdnav_set_readahead_flag
+ dvdnav_set_region_mask
+ dvdnav_spu_language_select
+@@ -72,11 +132,3 @@ dvdnav_set_PGC_positioning_flag
+ dvdnav_get_number_of_parts
+ dvdnav_reset
+ 
+-;------------------------------------------------------------
+-; timer exports
+-
+-gettimeofday
+-setitimer
+-pause
+-sleep
+-nanosleep

--- a/ports/libdvdnav/CMakeLists.txt
+++ b/ports/libdvdnav/CMakeLists.txt
@@ -1,0 +1,176 @@
+cmake_minimum_required(VERSION 3.20)
+
+set(DVDNAV_VERSION_MAJOR 6)
+set(DVDNAV_VERSION_MINOR 1)
+set(DVDNAV_VERSION_MICRO 1)
+set(DVDNAV_VERSION "${DVDNAV_VERSION_MAJOR}.${DVDNAV_VERSION_MINOR}.${DVDNAV_VERSION_MICRO}")
+set(PACKAGE_VERSION ${DVDNAV_VERSION})
+
+project(libdvdnav LANGUAGES C VERSION ${DVDNAV_VERSION})
+
+include(CheckIncludeFile)
+include(CheckFunctionExists)
+
+check_include_file(dlfcn.h HAVE_DLFCN_H)
+check_include_file(inttypes.h HAVE_INTTYPES_H)
+check_include_file(limits.h HAVE_LIMITS_H)
+check_include_file(memory.h HAVE_MEMORY_H)
+check_include_file(stdint.h HAVE_STDINT_H)
+check_include_file(stdlib.h HAVE_STDLIB_H)
+check_include_file(strings.h HAVE_STRINGS_H)
+check_include_file(string.h HAVE_STRING_H)
+check_include_file(sys/stat.h HAVE_SYS_STAT_H)
+check_include_file(sys/types.h HAVE_SYS_TYPES_H)
+check_include_file(unistd.h HAVE_UNISTD_H)
+
+check_function_exists(gettimeofday HAVE_GETTIMEOFDAY)
+
+if(MSVC)
+  add_definitions(-DWIN32_LEAN_AND_MEAN)
+  if (CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    set(_WIN32_IE "0x0A00")
+  else()
+    set(_WIN32_IE "0x0600")
+  endif()
+  set(UNUSED " ")
+else()
+  set(UNUSED "__attribute__((unused))")
+endif()
+
+set(PACKAGE "${PROJECT_NAME}")
+set(PACKAGE_NAME ${PACKAGE})
+set(PACKAGE_STRING "${PACKAGE} ${DVDNAV_VERSION}")
+set(PACKAGE_TARNAME ${PACKAGE})
+set(PACKAGE_URL "https://www.videolan.org/developers/libdvdnav.html")
+set(PACKAGE_VERSION ${DVDNAV_VERSION})
+set(STDC_HEADERS 1)
+set(SUPPORT_ATTRIBUTE_VISIBILITY_DEFAULT 1)
+set(SUPPORT_FLAG_VISIBILITY 1)
+set(VERSION ${DVDNAV_VERSION})
+
+set(DVDNAV_MAJOR ${DVDNAV_VERSION_MAJOR})
+set(DVDNAV_MINOR ${DVDNAV_VERSION_MAJOR})
+set(DVDNAV_SUB ${DVDNAV_VERSION_MICRO})
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cm ${CMAKE_BINARY_DIR}/config.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/dvdnav/version.h.in
+               ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdnav/version.h @ONLY)
+
+add_library(${PROJECT_NAME}
+	src/dvdnav.c
+	src/read_cache.c
+	src/navigation.c
+	src/highlight.c
+  src/logger.c
+  src/logger.h
+	src/searching.c
+	src/settings.c
+	src/dvdnav_internal.h
+	src/read_cache.h
+	src/vm/decoder.c
+	src/vm/decoder.h
+	src/vm/vm.c
+	src/vm/vm.h
+	src/vm/play.c
+	src/vm/play.h
+	src/vm/getset.c
+	src/vm/getset.h
+	src/vm/vmget.c
+	src/vm/vmcmd.c
+	src/vm/vmcmd.h
+)
+
+find_package(libdvdcss CONFIG REQUIRED)
+find_package(libdvdread CONFIG REQUIRED)
+
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+if(WIN32)
+target_include_directories(${PROJECT_NAME}
+  PRIVATE
+  "."
+  "src"
+  "src/dvdnav"
+  "msvc/include"
+  "msvc/contrib/dirent"
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+else(WIN32)
+target_include_directories(${PROJECT_NAME}
+  PRIVATE
+  "."
+  "src"
+  "src/dvdnav"
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+endif(WIN32)
+
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+      HAVE_CONFIG_H
+)
+
+if(MSVC)
+  target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+      _CRT_SECURE_NO_WARNINGS
+      _CRT_NONSTDC_NO_DEPRECATE
+      PATH_MAX=1024
+      WIN32_LEAN_AND_MEAN
+  )
+  set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_SOURCE_DIR}/msvc/libdvdnav.def\"")
+  if(CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+     # fix linkage with dvdcss
+     set_target_properties(${PROJECT_NAME}
+       PROPERTIES
+         LINK_FLAGS_DEBUG "/defaultlib:vccorlibd.lib /defaultlib:msvcrtd.lib"
+         LINK_FLAGS_RELEASE "/defaultlib:vccorlib.lib /defaultlib:msvcrt.lib"
+         LINK_FLAGS_RELWITHDEBINFO "/defaultlib:vccorlib.lib /defaultlib:msvcrt.lib"
+    )
+  endif()
+endif()
+
+target_link_libraries(
+        ${PROJECT_NAME}
+        PRIVATE
+        unofficial::libdvdcss::libdvdcss
+        unofficial::libdvdread::libdvdread
+)
+
+target_include_directories(${PROJECT_NAME}
+    INTERFACE
+        $<INSTALL_INTERFACE:include>
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-targets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdnav/dvd_types.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdnav/dvdnav.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdnav/dvdnav_events.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdnav/version.h
+  DESTINATION include/dvdnav)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  INSTALL_DESTINATION "share/${PROJECT_NAME}"
+)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  DESTINATION "share/${PROJECT_NAME}"
+)
+
+install(
+    EXPORT ${PROJECT_NAME}-targets
+    DESTINATION share/${PROJECT_NAME}
+    NAMESPACE unofficial::${PROJECT_NAME}::
+)

--- a/ports/libdvdnav/config.h.cm
+++ b/ports/libdvdnav/config.h.cm
@@ -1,0 +1,112 @@
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+#cmakedefine AC_APPLE_UNIVERSAL_BUILD 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#cmakedefine HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#cmakedefine HAVE_GETTIMEOFDAY 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#cmakedefine HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#cmakedefine HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#cmakedefine HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#cmakedefine HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#cmakedefine LT_OBJDIR "${LT_OBJDIR}"
+
+/* Name of package */
+#cmakedefine PACKAGE "${PACKAGE}"
+
+/* Define to the address where bug reports for this package should be sent. */
+#cmakedefine PACKAGE_BUGREPORT "${PACKAGE_BUGREPORT}"
+
+/* Define to the full name of this package. */
+#cmakedefine PACKAGE_NAME "${PACKAGE_NAME}"
+
+/* Define to the full name and version of this package. */
+#cmakedefine PACKAGE_STRING "${PACKAGE_STRING}"
+
+/* Define to the one symbol short name of this package. */
+#cmakedefine PACKAGE_TARNAME "${PACKAGE_TARNAME}"
+
+/* Define to the home page for this package. */
+#cmakedefine PACKAGE_URL "${PACKAGE_URL}"
+
+/* Define to the version of this package. */
+#cmakedefine PACKAGE_VERSION "${PACKAGE_VERSION}"
+
+/* Define to 1 if you have the ANSI C header files. */
+#cmakedefine STDC_HEADERS 1
+
+/* Unused parameter annotation */
+#cmakedefine UNUSED ${UNUSED}
+
+/* "Define to 1 to use builtin dlfcn" */
+#cmakedefine USING_BUILTIN_DLFCN 1
+
+/* Version number of package */
+#cmakedefine VERSION "${VERSION}"
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#cmakedefine _FILE_OFFSET_BITS ${_FILE_OFFSET_BITS}
+
+/* Define for large files, on AIX-style hosts. */
+#cmakedefine _LARGE_FILES 1
+
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#define inline __inline
+#define strcasecmp stricmp
+#define strncasecmp strnicmp
+
+#define S_ISDIR(m) ((m) & _S_IFDIR)
+#define S_ISREG(m) ((m) & _S_IFREG)
+#define S_ISBLK(m) 0
+#define S_ISCHR(m) 0
+
+#define PRIx64    "llx"
+#define PRId64    "lld"
+#endif

--- a/ports/libdvdnav/libdvdnav-config.cmake.in
+++ b/ports/libdvdnav/libdvdnav-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libdvdnav-targets.cmake")
+
+check_required_components(libdvdnav)

--- a/ports/libdvdnav/portfile.cmake
+++ b/ports/libdvdnav/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL "https://code.videolan.org/videolan/libdvdnav.git"
+    REF 9831fe01488bd0e9d1e3521195da6940cd8415eb # 6.1.1
+    HEAD_REF master
+    PATCHES
+        0001-fix-include-missing-on-windows.diff
+        0002-add-msvc-exports-def.diff
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/config.h.cm" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/libdvdnav-config.cmake.in" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libdvdnav/vcpkg.json
+++ b/ports/libdvdnav/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "libdvdnav",
+  "version-semver": "6.1.1",
+  "description": "Library to navigate DVD disks",
+  "homepage": "https://www.videolan.org/developers/libdvdnav.html",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    "libdvdcss",
+    "libdvdread",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/libdvdread/0001-fix-include-missing-on-windows.diff
+++ b/ports/libdvdread/0001-fix-include-missing-on-windows.diff
@@ -1,0 +1,69 @@
+commit 50e22aa0e8a75ecd32c75a342267272bc8a3cc95
+Author: Capric <capric8416@gmail.com>
+Date:   Thu Aug 29 15:18:43 2024 +0800
+
+    [hotfix] fix include missing on windows
+
+diff --git a/src/dvd_reader.c b/src/dvd_reader.c
+index c4d9641..6b74f95 100644
+--- a/src/dvd_reader.c
++++ b/src/dvd_reader.c
+@@ -61,6 +61,7 @@
+ #if defined(_WIN32)
+ # include <windows.h>
+ # include "msvc/contrib/win32_cs.h"
++# include <winsock2.h>
+ #endif
+ 
+ /* misc win32 helpers */
+diff --git a/src/dvd_udf.c b/src/dvd_udf.c
+index 4d90ba4..b341561 100644
+--- a/src/dvd_udf.c
++++ b/src/dvd_udf.c
+@@ -32,7 +32,9 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#if HAVE_STRINGS_H
+ #include <strings.h>
++#endif
+ 
+ #include <sys/types.h>
+ #include <sys/stat.h>
+diff --git a/src/dvdread/bitreader.h b/src/dvdread/bitreader.h
+index 801e3a9..109f2d5 100644
+--- a/src/dvdread/bitreader.h
++++ b/src/dvdread/bitreader.h
+@@ -21,6 +21,8 @@
+ #ifndef LIBDVDREAD_BITREADER_H
+ #define LIBDVDREAD_BITREADER_H
+ 
++#include <stdint.h>
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+diff --git a/src/dvdread/dvd_reader.h b/src/dvdread/dvd_reader.h
+index 54ef5dd..9246fc9 100644
+--- a/src/dvdread/dvd_reader.h
++++ b/src/dvdread/dvd_reader.h
+@@ -33,6 +33,7 @@
+ #include <sys/types.h>
+ #include <inttypes.h>
+ #include <stdarg.h>
++#include <stdint.h>
+ 
+ /**
+  * The DVD access interface.
+diff --git a/src/dvdread/ifo_types.h b/src/dvdread/ifo_types.h
+index 9293ce7..19cfa4c 100644
+--- a/src/dvdread/ifo_types.h
++++ b/src/dvdread/ifo_types.h
+@@ -23,6 +23,7 @@
+ #define LIBDVDREAD_IFO_TYPES_H
+ 
+ #include <inttypes.h>
++#include <stdint.h>
+ #include "dvdread/dvd_reader.h"
+ 
+ 

--- a/ports/libdvdread/0002-fix-uwp.diff
+++ b/ports/libdvdread/0002-fix-uwp.diff
@@ -1,0 +1,44 @@
+commit f4056ae4c1948030f80a85d977fc7bec38369c60
+Author: Capric <capric8416@gmail.com>
+Date:   Thu Aug 29 15:31:55 2024 +0800
+
+    [feature] add uwp support
+
+diff --git a/msvc/contrib/dlfcn.c b/msvc/contrib/dlfcn.c
+index 01b5781..027c5bb 100644
+--- a/msvc/contrib/dlfcn.c
++++ b/msvc/contrib/dlfcn.c
+@@ -36,6 +36,7 @@ void *dlopen(const char *module_name, int mode)
+      * same path or can be found in the usual places.  Failing that, let's
+      * let that dso look in the apache root.
+      */
++    #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+     em = SetErrorMode(SEM_FAILCRITICALERRORS);
+     dsoh = LoadLibraryEx(path, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+     if (!dsoh)
+@@ -45,6 +46,11 @@ void *dlopen(const char *module_name, int mode)
+     }
+     SetErrorMode(em);
+     SetLastError(0); // clear the last error
++    #else
++    wchar_t pathW[MAX_PATH];
++    mbstowcs(pathW, path, MAX_PATH);
++    dsoh = LoadPackagedLibrary(pathW, 0);
++    #endif
+     return (void *)dsoh;
+ }
+ 
+diff --git a/src/dvd_reader.c b/src/dvd_reader.c
+index 7ce6de1..dca3014 100644
+--- a/src/dvd_reader.c
++++ b/src/dvd_reader.c
+@@ -31,7 +31,9 @@
+ #include <string.h>         /* memcpy, strlen */
+ #include <unistd.h>         /* pclose */
+ #include <limits.h>         /* PATH_MAX */
++#if HAVE_DIRENT_H
+ #include <dirent.h>         /* opendir, readdir */
++#endif
+ #include <ctype.h>          /* isalpha */
+ 
+ #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__bsdi__) || defined(__APPLE__)

--- a/ports/libdvdread/0003-add-msvc-exports-def.diff
+++ b/ports/libdvdread/0003-add-msvc-exports-def.diff
@@ -1,0 +1,98 @@
+commit 117b6f345306efa46aab0d4b0b08502f28e37bbc
+Author: Capric <capric8416@gmail.com>
+Date:   Thu Aug 29 22:41:50 2024 +0800
+
+    [feature] add msvc exports def
+
+diff --git a/msvc/libdvdread.def b/msvc/libdvdread.def
+new file mode 100644
+index 0000000..13235a4
+--- /dev/null
++++ b/msvc/libdvdread.def
+@@ -0,0 +1,86 @@
++;------------------------------------------------------------
++; LIBDVDREAD DLL DEFINITIONS FILE
++
++EXPORTS
++
++
++
++; libdvdcss
++dvdcss_open
++dvdcss_open_stream
++dvdcss_close
++dvdcss_seek
++dvdcss_read
++dvdcss_readv
++dvdcss_error
++dvdcss_is_scrambled
++
++
++
++; libdvdread
++dvdread_getbits_init
++dvdread_getbits
++
++DVDOpen
++DVDOpen2
++DVDOpenStream
++DVDOpenStream2
++DVDClose
++DVDFileStat
++DVDOpenFile
++DVDCloseFile
++DVDReadBlocks
++DVDFileSeek
++DVDReadBytes
++DVDFileSize
++DVDDiscID
++DVDUDFVolumeInfo
++DVDFileSeekForce
++DVDISOVolumeInfo
++DVDUDFCacheLevel
++
++UDFFindFile
++UDFGetVolumeIdentifier
++UDFGetVolumeSetIdentifier
++
++ifo_print
++dvdread_print_time
++
++ifoOpen
++ifoOpenVMGI
++ifoOpenVTSI
++ifoClose
++ifoRead_PTL_MAIT
++ifoRead_VTS_ATRT
++ifoRead_TT_SRPT
++ifoRead_VTS_PTT_SRPT
++ifoRead_FP_PGC
++ifoRead_PGCIT
++ifoRead_PGCI_UT
++ifoRead_VTS_TMAPT
++ifoRead_C_ADT
++ifoRead_TITLE_C_ADT
++ifoRead_VOBU_ADMAP
++ifoRead_TITLE_VOBU_ADMAP
++ifoRead_TXTDT_MGI
++ifoFree_PTL_MAIT
++ifoFree_VTS_ATRT
++ifoFree_TT_SRPT
++ifoFree_VTS_PTT_SRPT
++ifoFree_FP_PGC
++ifoFree_PGCIT
++ifoFree_PGCI_UT
++ifoFree_VTS_TMAPT
++ifoFree_C_ADT
++ifoFree_TITLE_C_ADT
++ifoFree_VOBU_ADMAP
++ifoFree_TITLE_VOBU_ADMAP
++ifoFree_TXTDT_MGI
++
++navPrint_PCI
++navPrint_DSI
++
++navRead_DSI
++navRead_PCI
++
++

--- a/ports/libdvdread/CMakeLists.txt
+++ b/ports/libdvdread/CMakeLists.txt
@@ -1,0 +1,179 @@
+cmake_minimum_required(VERSION 3.20)
+
+set(DVDREAD_VERSION_MAJOR 6)
+set(DVDREAD_VERSION_MINOR 1)
+set(DVDREAD_VERSION_MICRO 3)
+set(DVDREAD_VERSION "${DVDREAD_VERSION_MAJOR}.${DVDREAD_VERSION_MINOR}.${DVDREAD_VERSION_MICRO}")
+set(PACKAGE_VERSION ${DVDREAD_VERSION})
+
+project(libdvdread LANGUAGES C VERSION ${DVDREAD_VERSION})
+
+if(MSVC)
+    add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+endif(MSVC)
+
+include(CheckIncludeFile)
+include(CheckFunctionExists)
+
+if(WIN32)
+check_include_file("${CMAKE_CURRENT_SOURCE_DIR}/msvc/contrib/dirent/dirent.h" HAVE_DIRENT_H)
+else(WIN32)
+check_include_file(dirent.h HAVE_DIRENT_H)
+endif(WIN32)
+check_include_file(dlfcn.h HAVE_DLFCN_H)
+check_include_file(inttypes.h HAVE_INTTYPES_H)
+check_include_file(limits.h HAVE_LIMITS_H)
+check_include_file(memory.h HAVE_MEMORY_H)
+check_include_file(stdint.h HAVE_STDINT_H)
+check_include_file(stdlib.h HAVE_STDLIB_H)
+check_include_file(strings.h HAVE_STRINGS_H)
+check_include_file(string.h HAVE_STRING_H)
+check_include_file(sys/param.h HAVE_SYS_PARAM_H)
+check_include_file(sys/stat.h HAVE_SYS_STAT_H)
+check_include_file(sys/types.h HAVE_SYS_TYPES_H)
+check_include_file(unistd.h HAVE_UNISTD_H)
+
+check_function_exists(gettimeofday HAVE_GETTIMEOFDAY)
+
+if(MSVC)
+  if (CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    add_definitions(/wd4146)
+  endif()
+endif()
+
+set(PACKAGE ${PROJECT_NAME})
+set(PACKAGE_NAME ${PROJECT_NAME})
+set(PACKAGE_STRING "${PROJECT_NAME} ${DVDREAD_VERSION}")
+set(PACKAGE_TARNAME ${PROJECT_NAME})
+set(PACKAGE_URL "https://www.videolan.org/developers/libdvdread.html")
+set(PACKAGE_VERSION ${DVDREAD_VERSION})
+set(STDC_HEADERS 1)
+set(SUPPORT_ATTRIBUTE_VISIBILITY_DEFAULT 1)
+set(SUPPORT_FLAG_VISIBILITY 1)
+set(VERSION ${DVDREAD_VERSION})
+set(_WIN32_IE "0x0600")
+#set(UNUSED "__attribute__((unused))")
+set(UNUSED " ")
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cm ${CMAKE_BINARY_DIR}/config.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/dvdread/version.h.in ${CMAKE_BINARY_DIR}/version.h @ONLY)
+
+add_library(${PROJECT_NAME}
+  src/bitreader.c
+  src/bswap.h
+  src/dvd_input.c
+  src/dvd_input.h
+  src/dvd_reader.c
+  src/dvd_udf.c
+  src/dvdread_internal.h
+  src/ifo_print.c
+  src/ifo_read.c
+  src/md5.c
+  src/md5.h
+  src/nav_print.c
+  src/nav_read.c
+  src/logger.c
+  src/logger.h
+)
+
+find_package(libdvdcss CONFIG REQUIRED)
+set(HAVE_DVDCSS_DVDCSS_H 1)
+
+add_library(unofficial::${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+if (WIN32)
+  if (CMAKE_BUILD_TYPE MATCHES Debug)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/nodefaultlib:vccorlibd /nodefaultlib:msvcrtd vccorlibd.lib msvcrtd.lib")
+  else(CMAKE_BUILD_TYPE MATCHES Debug)
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/nodefaultlib:vccorlib /nodefaultlib:msvcrt vccorlib.lib msvcrt.lib")
+  endif(CMAKE_BUILD_TYPE MATCHES Debug)
+endif(WIN32)
+
+if(WIN32)
+target_include_directories(${PROJECT_NAME}
+  PRIVATE
+  "."
+  "src"
+  "src/dvdread"
+  "msvc/include"
+  "msvc/contrib/dirent"
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+else()
+target_include_directories(${PROJECT_NAME}
+  PRIVATE
+  "."
+  "src"
+  "src/dvdread"
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+endif(WIN32)
+
+if(MSVC)
+  target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+      _CRT_SECURE_NO_WARNINGS
+      _CRT_NONSTDC_NO_DEPRECATE
+      PATH_MAX=1024
+      WIN32_LEAN_AND_MEAN
+  )
+  set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_SOURCE_DIR}/msvc/libdvdread.def\"")
+  if(CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+    set_target_properties(${PROJECT_NAME}
+        PROPERTIES
+          LINK_FLAGS_DEBUG "/defaultlib:vccorlibd.lib /defaultlib:msvcrtd.lib"
+          LINK_FLAGS_RELEASE "/defaultlib:vccorlib.lib /defaultlib:msvcrt.lib"
+          LINK_FLAGS_RELWITHDEBINFO "/defaultlib:vccorlib.lib /defaultlib:msvcrt.lib"
+    )
+  endif()
+endif()
+
+target_link_libraries(
+        ${PROJECT_NAME}
+        PRIVATE
+        unofficial::libdvdcss::libdvdcss
+)
+
+target_include_directories(${PROJECT_NAME}
+    INTERFACE
+        $<INSTALL_INTERFACE:include>
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-targets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdread/bitreader.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdread/dvd_reader.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdread/dvd_udf.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdread/ifo_print.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdread/ifo_read.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdread/ifo_types.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdread/nav_print.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdread/nav_read.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/dvdread/nav_types.h
+  ${CMAKE_CURRENT_BINARY_DIR}/version.h
+  DESTINATION include/dvdread)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  INSTALL_DESTINATION "share/${PROJECT_NAME}"
+)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  DESTINATION "share/${PROJECT_NAME}"
+)
+
+install(
+    EXPORT ${PROJECT_NAME}-targets
+    DESTINATION share/${PROJECT_NAME}
+    NAMESPACE unofficial::${PROJECT_NAME}::
+)

--- a/ports/libdvdread/config.h.cm
+++ b/ports/libdvdread/config.h.cm
@@ -1,0 +1,122 @@
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+#cmakedefine AC_APPLE_UNIVERSAL_BUILD 1
+
+/* Define to 1 if you have the <dirent.h> header file. */
+#cmakedefine HAVE_DIRENT_H 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#cmakedefine HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <dvdcss/dvdcss.h> header file. */
+#cmakedefine HAVE_DVDCSS_DVDCSS_H 1
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#cmakedefine HAVE_GETTIMEOFDAY 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <limits.h> header file. */
+#cmakedefine HAVE_LIMITS_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#cmakedefine HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#cmakedefine HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#cmakedefine HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#cmakedefine HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#cmakedefine HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#cmakedefine LT_OBJDIR "${LT_OBJDIR}"
+
+/* Name of package */
+#cmakedefine PACKAGE "${PACKAGE}"
+
+/* Define to the address where bug reports for this package should be sent. */
+#cmakedefine PACKAGE_BUGREPORT "${PACKAGE_BUGREPORT}"
+
+/* Define to the full name of this package. */
+#cmakedefine PACKAGE_NAME "${PACKAGE_NAME}"
+
+/* Define to the full name and version of this package. */
+#cmakedefine PACKAGE_STRING "${PACKAGE_STRING}"
+
+/* Define to the one symbol short name of this package. */
+#cmakedefine PACKAGE_TARNAME "${PACKAGE_TARNAME}"
+
+/* Define to the home page for this package. */
+#cmakedefine PACKAGE_URL "${PACKAGE_URL}"
+
+/* Define to the version of this package. */
+#cmakedefine PACKAGE_VERSION "${PACKAGE_VERSION}"
+
+/* Define to 1 if you have the ANSI C header files. */
+#cmakedefine STDC_HEADERS 1
+
+/* Unused parameter annotation */
+#cmakedefine UNUSED ${UNUSED}
+
+/* "Define to 1 to use builtin dlfcn" */
+#cmakedefine USING_BUILTIN_DLFCN 1
+
+/* Version number of package */
+#cmakedefine VERSION ${VERSION}
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#cmakedefine _FILE_OFFSET_BITS ${_FILE_OFFSET_BITS}
+
+/* Define for large files, on AIX-style hosts. */
+#cmakedefine _LARGE_FILES 1
+
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#define inline __inline
+#define strcasecmp stricmp
+#define strncasecmp strnicmp
+
+#define S_ISDIR(m) ((m) & _S_IFDIR)
+#define S_ISREG(m) ((m) & _S_IFREG)
+#define S_ISBLK(m) 0
+#define S_ISCHR(m) 0
+
+#endif

--- a/ports/libdvdread/libdvdread-config.cmake.in
+++ b/ports/libdvdread/libdvdread-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libdvdread-targets.cmake")
+
+check_required_components(libdvdread)

--- a/ports/libdvdread/portfile.cmake
+++ b/ports/libdvdread/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL "https://code.videolan.org/videolan/libdvdread.git"
+    REF ba2227bb8619724c2bfadcc4d8f25d741a3398ac # 6.1.3
+    HEAD_REF master
+    PATCHES
+        0001-fix-include-missing-on-windows.diff
+        0002-fix-uwp.diff
+        0003-add-msvc-exports-def.diff
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/config.h.cm" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/libdvdread-config.cmake.in" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/ports/libdvdread/vcpkg.json
+++ b/ports/libdvdread/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libdvdread",
+  "version-semver": "6.1.3",
+  "description": "Library to read DVD disks",
+  "homepage": "https://www.videolan.org/developers/libdvdnav.html",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    "libdvdcss",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4404,6 +4404,10 @@
       "baseline": "1.4.2",
       "port-version": 0
     },
+    "libdvdread": {
+      "baseline": "6.1.3",
+      "port-version": 0
+    },
     "libdwarf": {
       "baseline": "0.11.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4404,6 +4404,10 @@
       "baseline": "1.4.2",
       "port-version": 0
     },
+    "libdvdnav": {
+      "baseline": "6.1.1",
+      "port-version": 0
+    },
     "libdvdread": {
       "baseline": "6.1.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4400,6 +4400,10 @@
       "baseline": "0.6.0",
       "port-version": 3
     },
+    "libdvdcss": {
+      "baseline": "1.4.2",
+      "port-version": 0
+    },
     "libdwarf": {
       "baseline": "0.11.0",
       "port-version": 0

--- a/versions/l-/libdvdcss.json
+++ b/versions/l-/libdvdcss.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "57a335b47851da1090ff01fdaf9f916cbe0a92d1",
+      "version-semver": "1.4.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libdvdnav.json
+++ b/versions/l-/libdvdnav.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a86f6293192907be6f3af8ae81e4f589e4842dba",
+      "version-semver": "6.1.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libdvdread.json
+++ b/versions/l-/libdvdread.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "bdc1336393860753807059788446283e7158eced",
+      "version-semver": "6.1.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
